### PR TITLE
fix: correctly detect major version, for both angular and basic style

### DIFF
--- a/src/git_changelog/style.py
+++ b/src/git_changelog/style.py
@@ -17,7 +17,7 @@ class BasicStyle(CommitStyle):
     }
 
     TYPE_REGEX = re.compile(r"^(?P<type>(%s))" % "|".join(TYPES.keys()), re.I)
-    BREAK_REGEX = re.compile(r"^break(s|ing changes)?[ :].+$", re.I)
+    BREAK_REGEX = re.compile(r"^break(s|ing changes?)?[ :].+$", re.I | re.MULTILINE)
 
     def parse_commit(self, commit):
         commit_type = self.parse_type(commit.subject)
@@ -38,7 +38,7 @@ class BasicStyle(CommitStyle):
         return commit_type == self.TYPES["add"]
 
     def is_major(self, commit_message):
-        return bool(self.BREAK_REGEX.match(commit_message))
+        return bool(self.BREAK_REGEX.search(commit_message))
 
 
 class AngularStyle(CommitStyle):
@@ -56,7 +56,7 @@ class AngularStyle(CommitStyle):
         # 'chore': '',
     }
     SUBJECT_REGEX = re.compile(r"^(?P<type>(%s))(?:\((?P<scope>.+)\))?: (?P<subject>.+)$" % ("|".join(TYPES.keys())))
-    BREAK_REGEX = re.compile(r"^break(s|ing changes)?[ :].+$", re.I)
+    BREAK_REGEX = re.compile(r"^break(s|ing changes?)?[ :].+$", re.I | re.MULTILINE)
 
     def parse_commit(self, commit):
         subject = self.parse_subject(commit.subject)
@@ -86,7 +86,7 @@ class AngularStyle(CommitStyle):
         return commit_type == self.TYPES["feat"]
 
     def is_major(self, commit_message):
-        return bool(self.BREAK_REGEX.match(commit_message))
+        return bool(self.BREAK_REGEX.search(commit_message))
 
 
 class AtomStyle(CommitStyle):

--- a/tests/test_basic_style.py
+++ b/tests/test_basic_style.py
@@ -1,43 +1,43 @@
 from git_changelog.build import Commit
-from git_changelog.style import AngularStyle
+from git_changelog.style import BasicStyle
 
 
-def test_angular_style_breaking_change():
-    subject = "feat: this is a new breaking feature"
+def test_basic_style_breaking_change():
+    subject = "Added a new breaking feature"
     body = ["BREAKING CHANGE: there is a breaking feature in this code"]
     commit = Commit(hash="aaaaaaa", subject=subject, body=body, author_date="1574340645", committer_date="1574340645")
-    style = AngularStyle()
+    style = BasicStyle()
     commit_dict = style.parse_commit(commit)
     assert commit_dict["is_major"]
     assert not commit_dict["is_minor"]
     assert not commit_dict["is_patch"]
 
 
-def test_angular_style_breaking_changes():
-    subject = "feat: this is a new breaking feature"
+def test_basic_style_breaking_changes():
+    subject = "Added a new breaking feature"
     body = ["BREAKING CHANGES: there is a breaking feature in this code"]
     commit = Commit(hash="aaaaaaa", subject=subject, body=body, author_date="1574340645", committer_date="1574340645")
-    style = AngularStyle()
+    style = BasicStyle()
     commit_dict = style.parse_commit(commit)
     assert commit_dict["is_major"]
     assert not commit_dict["is_minor"]
     assert not commit_dict["is_patch"]
 
 
-def test_angular_style_feat():
-    subject = "feat: this is a new feature"
+def test_basic_style_feat():
+    subject = "Added a new feature"
     commit = Commit(hash="aaaaaaa", subject=subject, author_date="1574340645", committer_date="1574340645")
-    style = AngularStyle()
+    style = BasicStyle()
     commit_dict = style.parse_commit(commit)
     assert not commit_dict["is_major"]
     assert commit_dict["is_minor"]
     assert not commit_dict["is_patch"]
 
 
-def test_angular_style_fix():
-    subject = "fix: this is a bug fix"
+def test_basic_style_fix():
+    subject = "Fixed a bug"
     commit = Commit(hash="aaaaaaa", subject=subject, author_date="1574340645", committer_date="1574340645")
-    style = AngularStyle()
+    style = BasicStyle()
     commit_dict = style.parse_commit(commit)
     assert not commit_dict["is_major"]
     assert not commit_dict["is_minor"]


### PR DESCRIPTION
- fixed BREAK_REGEX to work on multiline commits
- added unit tests
- detect "BREAKING CHANGE" without the "S", according to https://www.conventionalcommits.org/en/v1.0.0/#examples

should close #8 