### PR TITLE
[WIP]feat: add a new template keepachangelog-strictly

### DIFF
--- a/src/git_changelog/templates/keepachangelog-strictly/changelog.md
+++ b/src/git_changelog/templates/keepachangelog-strictly/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+{% for version in changelog.versions_list -%}
+{% include 'version.md' with context %}
+{% endfor -%}

--- a/src/git_changelog/templates/keepachangelog-strictly/commit.md
+++ b/src/git_changelog/templates/keepachangelog-strictly/commit.md
@@ -1,0 +1,4 @@
+- {{ commit.subject|capitalize }} ([{{ commit.hash|truncate(7, True, '') }}]({{ commit.url }}) by {{ commit.author_name }}).
+{%- if commit.text_refs.issues_not_in_subject %} Related issues/PRs: {% for issue in commit.text_refs.issues_not_in_subject -%}
+{{ issue.ref }}{% if not loop.last %}, {% endif -%}
+{%- endfor -%}{%- endif -%}

--- a/src/git_changelog/templates/keepachangelog-strictly/section.md
+++ b/src/git_changelog/templates/keepachangelog-strictly/section.md
@@ -1,0 +1,4 @@
+### {{ section.type or "Misc" }}
+{% for commit in section.commits|sort(attribute='author_date',reverse=true)|unique(attribute='subject') -%}
+{% include 'commit.md' with context %}
+{% endfor %}

--- a/src/git_changelog/templates/keepachangelog-strictly/version.md
+++ b/src/git_changelog/templates/keepachangelog-strictly/version.md
@@ -1,0 +1,17 @@
+{%- if version.tag or version.planned_tag -%}
+## [{{ version.tag or version.planned_tag }}]({{ version.url }}) ([compare]({{ version.compare_url }}))
+{%- else -%}
+## Unrealeased ([compare]({{ version.compare_url }}))
+{%- endif -%}
+{% if version.date %} - {{ version.date }}{% endif %}
+
+{% for type, section in version.sections_dict|dictsort -%}
+{%- if type and type != 'Merged' -%}
+{% include 'section.md' with context %}
+{% endif -%}
+{%- endfor -%}
+{%- if version.untyped_section -%}
+{%- with section = version.untyped_section -%}
+{% include 'section.md' with context %}
+{% endwith -%}
+{%- endif -%}


### PR DESCRIPTION
I don't want to modify the "keepachangelog" but adding a new template, so that others can have a choice to use the "loose" style or the "strictly" style.

I have already used this template for some open-project projects, and I wish the official "git-changelog" can support this template to DRY the usage, otherwise I have to copy the template files to each project.

This template is based on template "keepachangelog", with following changes:

* capitalized commit subject
* show author name for each commit
* sort commits by date
* unique commit subject to keep notable

Here is a comparison:

"loose" style:
```
$ git-changelog --style basic --template "path:src/git_changelog/templates/keepachangelog" -o CHANGELOG-keepachangelog.md .
```
https://gist.github.com/rainchen/2d6b606f0425ce6e18f621d7230b3926#file-changelog-keepachangelog-md

"strictly" style:

```
$ git-changelog --style basic --template "path:src/git_changelog/templates/keepachangelog-strictly" -o CHANGELOG-keepachangelog-strictly.md .
```

https://gist.github.com/rainchen/2d6b606f0425ce6e18f621d7230b3926#file-changelog-keepachangelog-strictly-md


TODO: update cli to allow argument `-t keepachangelog-strictly`
