### PR TITLE
feat: Add ConventionalCommit commit type

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Automatic Changelog generator using Jinja2 templates. From git logs to change lo
   Built-in [Keep a Changelog][keep-a-changelog] and [Angular][angular] templates
   (also see [Conventional Changelog][conventional-changelog]).
 - Commit styles/conventions parsing.
-  Built-in [Angular][angular-style], [Atom][atom-style] and basic styles.
+  Built-in [Angular][angular-style], [Conventional Commit][conventional-commit], [Atom][atom-style] and basic styles.
 - Git service/provider agnostic,
   plus references parsing (issues, commits, etc.).
   Built-in [GitHub][github-refs] and [Gitlab][gitlab-refs] support.
@@ -38,6 +38,7 @@ Automatic Changelog generator using Jinja2 templates. From git logs to change lo
 [semantic-versioning]:    http://semver.org/spec/v2.0.0.html
 [atom-style]:             https://github.com/atom/atom/blob/master/CONTRIBUTING.md#git-commit-messages
 [angular-style]:          https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
+[conventional-commit]:    https://www.conventionalcommits.org/en/v1.0.0/
 [github-refs]:            https://help.github.com/articles/autolinked-references-and-urls/
 [gitlab-refs]:            https://docs.gitlab.com/ce/user/markdown.html#special-gitlab-references
 

--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, Type, Union
 
 from semver import VersionInfo
 
-from git_changelog.commit import AngularStyle, AtomStyle, BasicStyle, Commit, CommitStyle
+from git_changelog.commit import AngularStyle, AtomStyle, BasicStyle, Commit, CommitStyle, ConventionalCommitStyle
 from git_changelog.providers import GitHub, GitLab, ProviderRefParser
 
 StyleType = Optional[Union[str, CommitStyle, Type[CommitStyle]]]
@@ -142,7 +142,12 @@ class Changelog:
         r"%s%n"  # subject
         r"%b%n" + MARKER  # body
     )
-    STYLE: Dict[str, Type[CommitStyle]] = {"basic": BasicStyle, "angular": AngularStyle, "atom": AtomStyle}
+    STYLE: Dict[str, Type[CommitStyle]] = {
+        "basic": BasicStyle,
+        "angular": AngularStyle,
+        "atom": AtomStyle,
+        "conventional": ConventionalCommitStyle,
+    }
 
     def __init__(  # noqa: WPS231
         self,

--- a/tests/test_conventional_commit_style.py
+++ b/tests/test_conventional_commit_style.py
@@ -1,0 +1,119 @@
+"""Tests for the conventional commit style."""
+
+from git_changelog.commit import Commit, ConventionalCommitStyle
+
+
+def test_conventional_style_breaking_change():
+    """Breaking change (singular) is correctly identified."""
+    subject = "feat: this is a new breaking feature"
+    body = ["BREAKING CHANGE: there is a breaking feature in this code"]
+    commit = Commit(
+        commit_hash="aaaaaaa", subject=subject, body=body, author_date="1574340645", committer_date="1574340645"
+    )
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Features"
+    assert commit_dict["scope"] is None
+    assert commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]
+
+
+def test_conventional_style_breaking_changes():
+    """Breaking changes (plural) are correctly identified."""
+    subject = "feat: this is a new breaking feature"
+    body = ["BREAKING CHANGES: there is a breaking feature in this code"]
+    commit = Commit(
+        commit_hash="aaaaaaa", subject=subject, body=body, author_date="1574340645", committer_date="1574340645"
+    )
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Features"
+    assert commit_dict["scope"] is None
+    assert commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]
+
+
+def test_conventional_style_subject_breaking_change():  # noqa: WPS118
+    """Breaking change in the subject (!) are correctly identified."""
+    subject = "feat!: this is a new breaking feature"
+    body = ["There is a breaking feature in this code"]
+    commit = Commit(
+        commit_hash="aaaaaaa", subject=subject, body=body, author_date="1574340645", committer_date="1574340645"
+    )
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Features"
+    assert commit_dict["scope"] is None
+    assert commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]
+
+
+def test_conventional_style_subject_breaking_change_with_scope():  # noqa: WPS118
+    """Breaking change in the subject (!) with scope are correctly identified."""
+    subject = "feat(scope)!: this is a new breaking feature"
+    body = ["There is a breaking feature in this code"]
+    commit = Commit(
+        commit_hash="aaaaaaa", subject=subject, body=body, author_date="1574340645", committer_date="1574340645"
+    )
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Features"
+    assert commit_dict["scope"] == "scope"
+    assert commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]
+
+
+def test_conventional_style_feat():
+    """Feature commit is correctly identified."""
+    subject = "feat: this is a new feature"
+    commit = Commit(commit_hash="aaaaaaa", subject=subject, author_date="1574340645", committer_date="1574340645")
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Features"
+    assert commit_dict["scope"] is None
+    assert not commit_dict["is_major"]
+    assert commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]
+
+
+def test_conventional_style_feat_with_scope():
+    """Feature commit is correctly identified."""
+    subject = "feat(scope): this is a new feature"
+    commit = Commit(commit_hash="aaaaaaa", subject=subject, author_date="1574340645", committer_date="1574340645")
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Features"
+    assert commit_dict["scope"] == "scope"
+    assert not commit_dict["is_major"]
+    assert commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]
+
+
+def test_conventional_style_fix():
+    """Bug fix commit is correctly identified."""
+    subject = "fix: this is a bug fix"
+    commit = Commit(commit_hash="aaaaaaa", subject=subject, author_date="1574340645", committer_date="1574340645")
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Bug Fixes"
+    assert commit_dict["scope"] is None
+    assert not commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert commit_dict["is_patch"]
+
+
+def test_conventional_style_fix_with_scope():
+    """Bug fix commit is correctly identified."""
+    subject = "fix(scope): this is a bug fix"
+    commit = Commit(commit_hash="aaaaaaa", subject=subject, author_date="1574340645", committer_date="1574340645")
+    style = ConventionalCommitStyle()
+    commit_dict = style.parse_commit(commit)
+    assert commit_dict["type"] == "Bug Fixes"
+    assert commit_dict["scope"] == "scope"
+    assert not commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert commit_dict["is_patch"]


### PR DESCRIPTION
* See https://www.conventionalcommits.org/en/v1.0.0/
* This is based on the AngularCommit type.  The only major difference
  is that it allows breaking changes to be indicated by a "!" after
  the commit type and optional scope, and before the ":".

I created this PR this because I added an `!` to indicate a breaking change in a commit message, and it wasn't included in the corresponding changelog.

I implemented this the most straightforward way I could think of without changing `AngularCommit`.  However, I think a good (and simpler) alternative would be to modify the `AngularCommit` regex to recognize "!" in the subject line (and update `is_major` accordingly).  This doesn't match the Angular commit spec, though, so...

