### PR TITLE
feat: Add GIT_CHANGELOG_REMOTE variable

### DIFF
--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -243,7 +243,7 @@ class Changelog:
         Returns:
             The origin remote URL.
         """
-        remote = 'remote.' + os.environ.get('GIT_CHANGELOG_REMOTE', 'origin') + '.url'
+        remote = "remote." + os.environ.get("GIT_CHANGELOG_REMOTE", "origin") + ".url"
         git_url = self.run_git("config", "--get", remote).rstrip("\n")
         if git_url.startswith("git@"):
             git_url = git_url.replace(":", "/", 1).replace("git@", "https://", 1)

--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -2,6 +2,7 @@
 
 import datetime
 import sys
+import os
 from subprocess import check_output  # noqa: S404 (we trust the commands we run)
 from typing import Dict, List, Optional, Tuple, Type, Union
 
@@ -242,7 +243,8 @@ class Changelog:
         Returns:
             The origin remote URL.
         """
-        git_url = self.run_git("config", "--get", "remote.origin.url").rstrip("\n")
+        remote = 'remote.' + os.environ.get('GIT_CHANGELOG_REMOTE', 'origin') + '.url'
+        git_url = self.run_git("config", "--get", remote).rstrip("\n")
         if git_url.startswith("git@"):
             git_url = git_url.replace(":", "/", 1).replace("git@", "https://", 1)
         if git_url.endswith(".git"):

--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -1,8 +1,8 @@
 """The module responsible for building the data."""
 
 import datetime
-import sys
 import os
+import sys
 from subprocess import check_output  # noqa: S404 (we trust the commands we run)
 from typing import Dict, List, Optional, Tuple, Type, Union
 


### PR DESCRIPTION
Hey,

in my workflow, I clone repositories as `upstream` remote name and my fork as `origin`. Unfortunately, git-changelog does not like that, this leads to me uploading CHANGELOG with links to my fork rather to the upstream repository.

I thought for introducing an option for a moment, but what I absolutely adore about this project is that it "just works" out of box! Compared to my previous experience, it was a treat!

So here is my proposal of environmental variable. I would not bother documenting this becuase this is quite rare workflow I think, this is not the first time I run into issue with this. Alternatively, I could change the patch to search for "upstream" remote first, if it does not exists it would fallback to "origin".

Let's see what you like, cheers!