### PR TITLE
Update version regex

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -335,7 +335,7 @@ To support in-place updates in a custom template, you have two choices:
     to insert new entries. Here are these default values:
 
     ```python
-    DEFAULT_VERSION_REGEX = r"^## \[v?(?P<version>[^\]]+)"
+    DEFAULT_VERSION_REGEX = r"^## \[(?P<version>v?[^\]]+)"
     DEFAULT_MARKER_LINE = "<!-- insertion marker -->"
     ```
 

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 8):
 else:
     from importlib import metadata
 
-DEFAULT_VERSION_REGEX = r"^## \[v?(?P<version>[^\]]+)"
+DEFAULT_VERSION_REGEX = r"^## \[(?P<version>v?[^\]]+)"
 DEFAULT_MARKER_LINE = "<!-- insertion marker -->"
 CONVENTIONS = ("angular", "atom", "conventional", "basic")
 

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -350,6 +350,10 @@ def build_and_render(
         # only keep new entries (missing from changelog)
         last_released = _latest(lines, re.compile(version_regex))
         if last_released:
+            # check if the latest version is already in the changelog
+            if (last_released == changelog.versions_list[0].tag or
+                last_released == changelog.versions_list[0].planned_tag):
+                raise ValueError(f"Version {last_released} already in changelog")
             changelog.versions_list = _unreleased(
                 changelog.versions_list,
                 last_released,


### PR DESCRIPTION
For repositories which mark versions with a `v` before the version
numbers, the `v` needs to be included in the captured version from the
changelog, or we won't find a matching version for filtering out already
added entries, and they will be duplicated.

Also check if the latest version tag is already part of the changelog.