### PR TITLE
feat: Add Bitbucket provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL := bash
 DUTY := $(if $(VIRTUAL_ENV),,pdm run) duty
-export PDM_MULTIRUN_VERSIONS ?= 3.8 3.9 3.10 3.11
+export PDM_MULTIRUN_VERSIONS ?= 3.8 3.9 3.10 3.11 3.12
 
 args = $(foreach a,$($(subst -,_,$1)_args),$(if $(value $a),$a="$($a)"))
 check_quality_args = files

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Automatic Changelog generator using Jinja2 templates. From git logs to change lo
   Built-in [Angular][angular-convention], [Conventional Commit][conventional-commit], [Atom][atom-convention] and basic conventions.
 - Git service/provider agnostic,
   plus references parsing (issues, commits, etc.).
-  Built-in [GitHub][github-refs] and [Gitlab][gitlab-refs] support.
+  Built-in [GitHub][github-refs], [Gitlab][gitlab-refs] and [Bitbucket][bitbucket-refs] support.
 - Understands [Semantic Versioning][semantic-versioning]:
   major/minor/patch for versions and commits.
   Guesses next version based on last commits.
@@ -44,6 +44,7 @@ Automatic Changelog generator using Jinja2 templates. From git logs to change lo
 [conventional-commit]:    https://www.conventionalcommits.org/en/v1.0.0/
 [github-refs]:            https://help.github.com/articles/autolinked-references-and-urls/
 [gitlab-refs]:            https://docs.gitlab.com/ce/user/markdown.html#special-gitlab-references
+[bitbucket-refs]:         https://support.atlassian.com/bitbucket-cloud/docs/markup-comments
 [git-trailers]:           https://git-scm.com/docs/git-interpret-trailers
 
 [issue-14]: https://github.com/pawamoy/git-changelog/issues/14
@@ -168,7 +169,7 @@ options:
                         insertion marker -->.
   -o, --output OUTPUT   Output to given file. Default: stdout.
   -r, --parse-refs      Parse provider-specific references in commit messages
-                        (GitHub/GitLab issues, PRs, etc.). Default: False.
+                        (GitHub/GitLab/Bitbucket issues, PRs, etc.). Default: False.
   -R, --release-notes   Output release notes to stdout based on the last entry
                         in the changelog. Default: False.
   -I, --input INPUT     Read from given file when creating release notes.

--- a/config/ruff.toml
+++ b/config/ruff.toml
@@ -71,6 +71,7 @@ ignore = [
     "PLR0915",  # Too many statements
     "SLF001", # Private member accessed
     "TRY003",  # Avoid specifying long messages outside the exception class
+    "UP032",  # Use f-string instead of `format` call
 ]
 
 [per-file-ignores]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ Update a changelog in-place, overwriting and updating the "Unreleased" section,
 using the Angular commit message convention and the Keep A Changelog template (default):
 
 ```bash
-git-changelog -io CHANGELOG.md -c angular  
+git-changelog -io CHANGELOG.md -c angular
 ```
 
 Same thing, but now you're ready to tag so you tell *git-changelog*
@@ -43,10 +43,10 @@ git-changelog -Tbio CHANGELOG.md -c angular -s build,deps,fix,feat,refactor
 ```
 
 Generate a changelog using a custom template,
-and parsing provider-specific references (GitHub/GitLab):
+and parsing provider-specific references (GitHub/GitLab/Bitbucket):
 
 ```bash
-git-changelog -rt path:./templates/changelog.md.jinja 
+git-changelog -rt path:./templates/changelog.md.jinja
 ```
 
 Author's favorite, from Python:
@@ -113,14 +113,14 @@ If a commit message summary (the first line of the message)
 with a particular word/prefix (case-insensitive),
 it is added to the corresponding section:
 
-Type    | Section
-------- | -------
-`add`     | Added
-`fix`     | Fixed
-`change`  | Changed
-`remove`  | Removed
-`merge`   | Merged
-`doc`     | Documented
+Type     | Section
+---------|-----------
+`add`    | Added
+`fix`    | Fixed
+`change` | Changed
+`remove` | Removed
+`merge`  | Merged
+`doc`    | Documented
 
 ### Angular/Karma convention
 
@@ -137,20 +137,20 @@ It expects the following format for commit messages:
 
 The types and corresponding sections *git-changelog* recognizes are:
 
-Type          | Section
-------------- | -------
-`build`       | Build
-`chore`       | Chore
-`ci`          | Continuous Integration
-`deps`        | Dependencies
-`doc(s)`      | Docs
-`feat`        | Features
-`fix`         | Bug Fixes
-`perf`        | Performance Improvements
-`ref(actor)`  | Code Refactoring
-`revert`      | Reverts
-`style`       | Style
-`test(s)`     | Tests
+Type         | Section
+-------------|-------------------------
+`build`      | Build
+`chore`      | Chore
+`ci`         | Continuous Integration
+`deps`       | Dependencies
+`doc(s)`     | Docs
+`feat`       | Features
+`fix`        | Bug Fixes
+`perf`       | Performance Improvements
+`ref(actor)` | Code Refactoring
+`revert`     | Reverts
+`style`      | Style
+`test(s)`    | Tests
 
 Breaking changes are detected by searching for `^break(s|ing changes?)?[ :]`
 in the commit message body.
@@ -196,7 +196,7 @@ You can get inspiration from
 
 ## Understand the relationship with SemVer
 
-[Semver](semver), or Semantic Versioning, helps users of tools and libraries
+[Semver][semver], or Semantic Versioning, helps users of tools and libraries
 understand the impact of version changes. To quote SemVer itself:
 
 > Given a version number MAJOR.MINOR.PATCH, increment the:
@@ -226,7 +226,7 @@ to find additional information.
 
 ### Provider-specific references
 
-*git-changelog* will detect when you are using GitHub or GitLab
+*git-changelog* will detect when you are using GitHub, GitLab or Bitbucket
 by checking the `origin` remote configured in your local clone
 (or the remote indicated by the value of the `GIT_CHANGELOG_REMOTE` environment variable).
 
@@ -281,9 +281,9 @@ Part of epic #5: https://agile-software.com/super/project/epics/5
 ```
 
 As you can see, compared to provider-specific references,
-trailers are written out explicitely, so it's a bit more work,
+trailers are written out explicitly, so it's a bit more work,
 but this ensures your changelog can be rendered correctly *anywhere*,
-not just on GitHub or GitLab, and without pre/post-processing.
+not just on GitHub, GitLab or Bitbucket, and without pre/post-processing.
 
 Trailers are rendered in the Keep A Changelog template.
 If the value is an URL, a link is created with the token as title.

--- a/src/git_changelog/__init__.py
+++ b/src/git_changelog/__init__.py
@@ -5,6 +5,6 @@ Automatic Changelog generator using Jinja2 templates.
 
 from __future__ import annotations
 
-from git_changelog.build import Changelog, Commit, GitHub, GitLab
+from git_changelog.build import Bitbucket, Changelog, Commit, GitHub, GitLab
 
-__all__: list[str] = ["Changelog", "Commit", "GitHub", "GitLab"]
+__all__: list[str] = ["Bitbucket", "Changelog", "Commit", "GitHub", "GitLab"]

--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -20,7 +20,7 @@ from git_changelog.commit import (
     CommitConvention,
     ConventionalCommitConvention,
 )
-from git_changelog.providers import GitHub, GitLab, ProviderRefParser
+from git_changelog.providers import Bitbucket, GitHub, GitLab, ProviderRefParser
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -197,6 +197,8 @@ class Changelog:
                 provider = GitHub(namespace, project, url=provider_url)
             elif "gitlab" in provider_url:
                 provider = GitLab(namespace, project, url=provider_url)
+            elif "bitbucket" in provider_url:
+                provider = Bitbucket(namespace, project, url=provider_url)
             self.remote_url: str = remote_url
         self.provider = provider
 

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -358,6 +358,7 @@ def build_and_render(
         with open(output, "w") as changelog_file:  # type: ignore[arg-type]
             changelog_file.write("\n".join(lines).rstrip("\n") + "\n")
 
+    # overwrite output file
     else:
         rendered = jinja_template.render(changelog=changelog)
 

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -171,7 +171,7 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="parse_refs",
         default=False,
-        help="Parse provider-specific references in commit messages (GitHub/GitLab issues, PRs, etc.). Default: %(default)s.",
+        help="Parse provider-specific references in commit messages (GitHub/GitLab/Bitbucket issues, PRs, etc.). Default: %(default)s.",
     )
     parser.add_argument(
         "-R",

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -330,10 +330,10 @@ def build_and_render(
         last_released = _latest(lines, re.compile(version_regex))
         if last_released:
             # check if the latest version is already in the changelog
-            if (
-                last_released == changelog.versions_list[0].tag
-                or last_released == changelog.versions_list[0].planned_tag
-            ):
+            if last_released in [
+                changelog.versions_list[0].tag,
+                changelog.versions_list[0].planned_tag,
+            ]:
                 raise ValueError(f"Version {last_released} already in changelog")
             changelog.versions_list = _unreleased(
                 changelog.versions_list,
@@ -358,7 +358,6 @@ def build_and_render(
         with open(output, "w") as changelog_file:  # type: ignore[arg-type]
             changelog_file.write("\n".join(lines).rstrip("\n") + "\n")
 
-    # overwrite output file
     else:
         rendered = jinja_template.render(changelog=changelog)
 

--- a/src/git_changelog/commit.py
+++ b/src/git_changelog/commit.py
@@ -6,7 +6,7 @@ import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import suppress
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, Pattern
 
 if TYPE_CHECKING:
@@ -59,11 +59,11 @@ class Commit:
         if not author_date:
             author_date = datetime.now()  # noqa: DTZ005
         elif isinstance(author_date, str):
-            author_date = datetime.utcfromtimestamp(float(author_date))  # noqa: DTZ004
+            author_date = datetime.fromtimestamp(float(author_date), tz=timezone.utc)
         if not committer_date:
             committer_date = datetime.now()  # noqa: DTZ005
         elif isinstance(committer_date, str):
-            committer_date = datetime.utcfromtimestamp(float(committer_date))  # noqa: DTZ004
+            committer_date = datetime.fromtimestamp(float(committer_date), tz=timezone.utc)
 
         self.hash: str = commit_hash
         self.author_name: str = author_name

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -24,6 +24,8 @@ A commit range: 00000000...11111111
 A snippet: $45
 Some labels: ~18, ~bug, ~"multi word label"
 Some milestones: %2, %version1, %"awesome version"
+A Bitbucket PR: Pull request #1
+A Bitbucket issue: Issue #1
 """
 
 
@@ -39,3 +41,9 @@ def test_gitlab_issue_parsing() -> None:
     gitlab = git_changelog.GitLab("pawamoy", "git-changelog")
     for ref in gitlab.REF:
         assert gitlab.get_refs(ref, text)
+
+def test_bitbucket_issue_parsing() -> None:
+    """Bitbucket issues are correctly parsed."""
+    bitbucket = git_changelog.Bitbucket("pawamoy", "git-changelog")
+    for ref in bitbucket.REF:
+        assert bitbucket.get_refs(ref, text)


### PR DESCRIPTION
Add Bitbucket as a standard provider. While less common than GitHub/GitLab, it is used by a fair amount of people.