### PR TITLE
WIP: Customizing code convention

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -514,13 +514,9 @@ convention:
 sections = "fix,add,change,remove,doc,maint"
 
 [tool.git-changelog.conventions.basic]
-add = 'Added'
-change = 'Changed'
-ci = 'Maintenance'
+merge = ''
 doc = 'Documentation'
-fix = 'Fixed'
 maint = 'Maintenance'
-remove = 'Removed'
 ```
 
 This configuration would remove the `merge` type of commits, and
@@ -529,31 +525,33 @@ It also overrides the title of `doc` commits, from `"Documented"` to `"Documenta
 Finally, and to keep synchrony with the changes generator, the `sections` general setting
 is also specified.
 
-If the `sections` setting is not present and the convention selected is `basic`, then
-`sections` will be overwritten to the customized new convention, in the order it is
-specified. In other words, the above `pyproject.toml` would be equivalent to:
-
-```toml
-[tool.git-changelog.conventions.basic]
-fix = 'Fixed'
-add = 'Added'
-change = 'Changed'
-remove = 'Removed'
-doc = 'Documentation'
-maint = 'Maintenance'
-ci = 'Maintenance'
-```
-
-where the entries of the convention are ordered, and all will be present in the generated
-changelog.
-If two commit types point to the same section, only the first of them
-(`maint` in the above example) will be listed as section.
-
 ### Commit conventions: creating a custom convention
 
 ```toml
 [tool.git-changelog]
 convention = 'myconvention'
+
+[tool.git-changelog.conventions.myconvention]
+fix = 'Bug fixes'
+enh = 'New features and enhancements'
+feat = 'New features and enhancements'
+doc = 'Documentation'
+docs = 'Documentation'
+maint = 'Maintenance and continuous integration'
+chore = 'Maintenance and continuous integration'
+ci = 'Maintenance and continuous integration'
+sty = 'Code style and comments'
+style = 'Code style and comments'
+```
+
+If the `sections` setting is not present and the convention selected is `myconvention`,
+then `sections` will be generated based in the order the commit types are specified.
+In the above example, this is equivalent to:
+
+```toml
+[tool.git-changelog]
+convention = 'myconvention'
+sections = ['fix', 'enh', 'doc', 'maint', 'sty']
 
 [tool.git-changelog.conventions.myconvention]
 fix = 'Bug fixes'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -503,6 +503,71 @@ template = "keepachangelog"
 version-regex = "^## \\\\[(?P<version>v?[^\\\\]]+)"
 ```
 
+### Commit conventions: updating defaults
+
+Predefined code conventions can be altered within settings files.
+For example, the following `pyproject.toml` would edit the *basic*
+convention:
+
+```toml
+[tool.git-changelog]
+sections = "fix,add,change,remove,doc,maint"
+
+[tool.git-changelog.conventions.basic]
+add = 'Added'
+change = 'Changed'
+ci = 'Maintenance'
+doc = 'Documentation'
+fix = 'Fixed'
+maint = 'Maintenance'
+remove = 'Removed'
+```
+
+This configuration would remove the `merge` type of commits, and
+introduce the `maint` commit set.
+It also overrides the title of `doc` commits, from `"Documented"` to `"Documentation"`.
+Finally, and to keep synchrony with the changes generator, the `sections` general setting
+is also specified.
+
+If the `sections` setting is not present and the convention selected is `basic`, then
+`sections` will be overwritten to the customized new convention, in the order it is
+specified. In other words, the above `pyproject.toml` would be equivalent to:
+
+```toml
+[tool.git-changelog.conventions.basic]
+fix = 'Fixed'
+add = 'Added'
+change = 'Changed'
+remove = 'Removed'
+doc = 'Documentation'
+maint = 'Maintenance'
+ci = 'Maintenance'
+```
+
+where the entries of the convention are ordered, and all will be present in the generated
+changelog.
+If two commit types point to the same section, only the first of them
+(`maint` in the above example) will be listed as section.
+
+### Commit conventions: creating a custom convention
+
+```toml
+[tool.git-changelog]
+convention = 'myconvention'
+
+[tool.git-changelog.conventions.myconvention]
+fix = 'Bug fixes'
+enh = 'New features and enhancements'
+feat = 'New features and enhancements'
+doc = 'Documentation'
+docs = 'Documentation'
+maint = 'Maintenance and continuous integration'
+chore = 'Maintenance and continuous integration'
+ci = 'Maintenance and continuous integration'
+sty = 'Code style and comments'
+style = 'Code style and comments'
+```
+
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [conventional-commit]: https://www.conventionalcommits.org/en/v1.0.0-beta.4/
 [jinja]: https://jinja.palletsprojects.com/en/3.1.x/


### PR DESCRIPTION
Requires: #55 .

@pawamoy please have a look at the `usage.md` file changes w.r.t. the #55 feature branch - does it sound like a reasonable plan? Quick link for the diff: https://github.com/oesteban/git-changelog/compare/feat/config-files...oesteban:git-changelog:feat/modify-commit-convention