### PR TITLE
feat: Add `-F,--filter-commits` to filter by revision-range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ pdm.toml
 __pypackages__/
 .venv/
 .cache/
-.helix

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pdm.toml
 __pypackages__/
 .venv/
 .cache/
+.helix

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,6 +201,29 @@ Templates are single files written using the [Jinja][jinja] templating engine.
 You can get inspiration from
 [the source of our built-in templates](https://github.com/pawamoy/git-changelog/tree/master/src/git_changelog/templates).
 
+## Filter commits
+
+Sometimes it may be useful to use a limited set of commits, for example, if your
+project has migrated to semver recently and you want to ignore old non-conventional commits.
+
+This is possible through the option `-F`, `--filter-commits`, which takes a
+*revision-range* to select the commits that will be used in the changelog.
+This option will pass the [revision-range](https://git-scm.com/docs/git-log#
+Documentation/git-log.txt-ltrevision-rangegt) to `git log`, so it will follow 
+the rules defined by Git.
+
+For example, to use commits from tag `0.5.0` up to latest:
+
+```bash
+git-changelog --filter-commits "0.5.0.."
+```
+
+Or using the commit hash:
+
+```bash
+git-changelog --filter-commits "2c0dbb8.."
+```
+
 ## Understand the relationship with SemVer
 
 [Semver][semver], or Semantic Versioning, helps users of tools and libraries
@@ -438,17 +461,6 @@ Other options can be used to help *git-changelog* retrieving
 the latest entry from your changelog: `--version-regex`
 and `--marker-line`.
 
-## Filter commits
-
-Sometimes it may be useful to use a limited set of commits, for example, if your
-project has migrated to semver recently and you want to ignore old non-conventional commits.
-
-This is possible through the option `-F`, `--filter-commits`, which takes a
-*revision-range* to select the commits that will be used in the changelog.
-This option will pass the [revision-range](https://git-scm.com/docs/git-log#
-Documentation/git-log.txt-ltrevision-rangegt) to `git log`, so it will follow 
-the rules defined by Git.
-
 ## Configuration files
 
 Project-wise, permanent configuration of *git-changelog* is possible.
@@ -485,6 +497,7 @@ for most of the command line options:
 bump = "auto"
 convention = "basic"
 in-place = false
+filter-commits = "0.5.0.."
 marker-line = "<!-- insertion marker -->"
 output = "output.log"
 parse-refs = false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -438,6 +438,16 @@ Other options can be used to help *git-changelog* retrieving
 the latest entry from your changelog: `--version-regex`
 and `--marker-line`.
 
+## Filter commits
+
+Sometimes it may be useful to use a limited set of commits, for example, if your
+project has migrated to semver recently and you want to ignore old non-conventional commits.
+
+This is possible through the option `-F`, `--filter-commits`, which takes a
+*revision-range* to select the commits that will be used in the changelog.
+This option will pass the [revision-range](https://git-scm.com/docs/git-log#
+Documentation/git-log.txt-ltrevision-rangegt) to `git log`, so it will follow 
+the rules defined by Git.
 
 ## Configuration files
 

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -57,6 +57,7 @@ DEFAULT_SETTINGS = {
     "bump": None,
     "bump_latest": None,
     "convention": "basic",
+    "filter_commits": None,
     "in_place": False,
     "input": DEFAULT_CHANGELOG_FILE,
     "marker_line": DEFAULT_MARKER_LINE,

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -306,6 +306,13 @@ def get_parser() -> argparse.ArgumentParser:
         help="Omit empty versions from the output. Default: unset (false).",
     )
     parser.add_argument(
+        "-F",
+        "--filter-commits",
+        action="store",
+        dest="filter_commits",
+        help="The Git revision-range filter to use (e.g. 'v1.2.0..'). Default: no filter",
+    )
+    parser.add_argument(
         "-V",
         "--version",
         action="version",
@@ -457,6 +464,7 @@ def build_and_render(
     omit_empty_versions: bool = False,  # noqa: FBT001,FBT002
     provider: str | None = None,
     bump: str | None = None,
+    filter_commits: str | None = None,
 ) -> tuple[Changelog, str]:
     """Build a changelog and render it.
 
@@ -479,6 +487,7 @@ def build_and_render(
         omit_empty_versions: Whether to omit empty versions from the output.
         provider: Provider class used by this repository.
         bump: Whether to try and bump to a given version.
+        filter_commits: The Git revision-range used to filter commits in git-log.
 
     Raises:
         ValueError: When some arguments are incompatible or missing.
@@ -521,6 +530,7 @@ def build_and_render(
         parse_trailers=parse_trailers,
         sections=sections,
         bump=bump,
+        filter_commits=filter_commits,
     )
 
     # remove empty versions from changelog data


### PR DESCRIPTION
This feature adds support for filtering the commits that will be used by git-changelog

Issue #63: https://github.com/pawamoy/git-changelog/issues/63
Issue #16: https://github.com/pawamoy/git-changelog/issues/16