### PR TITLE
fix: Ignore bump on new git repo without unreleased commits

### DIFF
--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -443,7 +443,7 @@ class Changelog:
 
     def _fix_single_version(self, version: str | None) -> None:
         last_version = self.versions_list[0]
-        if len(self.versions_list) == 1 and last_version.planned_tag is None:
+        if len(self.versions_list) == 1 and last_version.planned_tag is None and not last_version.tag:
             planned_tag = version if version and version not in {"auto", "major", "minor", "patch"} else "0.1.0"
             last_version.tag = planned_tag
             last_version.url += planned_tag

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -58,3 +58,11 @@ class GitRepo:
         self.git("add", "-A")
         self.git("commit", "-m", message)
         return self.git("rev-parse", "HEAD")
+
+    def tag(self, tagname: str) -> None:
+        """Create a new tag in the GIt repository.
+
+        Parameters:
+            tagname: The name of the new tag.
+        """
+        self.git("tag", tagname)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -22,8 +22,24 @@ def test_bump_with_semver_on_new_repo(repo: GitRepo, bump: str, expected: str) -
 
     Parameters:
         repo: GitRepo to a temporary repository.
+        bump: The bump parameter value.
         expected: Expected version for the new changelog entry.
     """
     changelog = Changelog(repo.path, convention=AngularConvention, bump=bump)
     assert len(changelog.versions_list) == 1
     assert changelog.versions_list[0].tag == expected
+
+
+@pytest.mark.parametrize("bump", ["auto", "major", "minor", "2.0.0"])
+def test_no_bump_on_first_tag(repo: GitRepo, bump: str) -> None:
+    """Ignore bump on new git repo without unreleased commits.
+
+    Parameters:
+        repo: GitRepo to a temporary repository.
+        bump: The bump parameter value.
+    """
+    repo.tag("1.1.1")
+
+    changelog = Changelog(repo.path, convention=AngularConvention, bump=bump)
+    assert len(changelog.versions_list) == 1
+    assert changelog.versions_list[0].tag == "1.1.1"


### PR DESCRIPTION
If a Git repository has no unreleased commits and only one version/tag, the original tag/version was ignored and instead the version was determined by the "bump" parameter.

For example:

``` mermaid
gitGraph
    commit id: "A"
    commit id: "B" tag: "1.1.1"
```

Results in:

- with bump in (auto, major, minor, patch): Version "0.1.0"
- with bump a semver, e. g. "1.0.0": Version is the given semver, "1.0.0"

This PR fixes this by ignoring the bump parameter if there is only one tag and the tag is on the last commit.