### PR TITLE
Assign commits to versions following their commit graph (fixes #70) 

### DIFF
--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -443,7 +443,7 @@ class Changelog:
 
     def _fix_single_version(self, version: str | None) -> None:
         last_version = self.versions_list[0]
-        if len(self.versions_list) == 1 and last_version.planned_tag is None:
+        if len(self.versions_list) == 1 and last_version.planned_tag is None and not last_version.tag:
             planned_tag = version if version and version not in {"auto", "major", "minor", "patch"} else "0.1.0"
             last_version.tag = planned_tag
             last_version.url += planned_tag

--- a/src/git_changelog/commit.py
+++ b/src/git_changelog/commit.py
@@ -34,6 +34,7 @@ class Commit:
         committer_email: str = "",
         committer_date: str | datetime = "",
         refs: str = "",
+        parent_hashes: str | list[str] = "",
         subject: str = "",
         body: list[str] | None = None,
         url: str = "",
@@ -84,6 +85,12 @@ class Commit:
                 break
         self.tag: str = tag
         self.version: str = tag
+
+        if isinstance(parent_hashes, str):
+            self.parent_hashes = parent_hashes.split(" ")
+        else:
+            self.parent_hashes = parent_hashes
+        self.parent_commits: list[Commit] = []
 
         self.text_refs: dict[str, list[Ref]] = {}
         self.convention: dict[str, Any] = {}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,7 +28,7 @@ class GitRepo:
         self.git("config", "user.name", "dummy")
         self.git("config", "user.email", "dummy@example.com")
         self.git("remote", "add", "origin", "git@github.com:example/example")
-        self.commit("chore: Initial repository creation")
+        self.first_hash = self.commit("chore: Initial repository creation")
 
     def git(self, *args: str) -> str:
         """Run a Git command in the repository.
@@ -57,7 +57,7 @@ class GitRepo:
             fh.write(str(random.randint(0, 1)))  # noqa: S311
         self.git("add", "-A")
         self.git("commit", "-m", message)
-        return self.git("rev-parse", "HEAD")
+        return self.git("rev-parse", "HEAD").rstrip()
 
     def tag(self, tagname: str) -> None:
         """Create a new tag in the GIt repository.
@@ -66,3 +66,31 @@ class GitRepo:
             tagname: The name of the new tag.
         """
         self.git("tag", tagname)
+
+    def branch(self, branchname: str) -> None:
+        """Create a new branch in the GIt repository.
+
+        Parameters:
+            branchname: The name of the new branch.
+        """
+        self.git("branch", branchname)
+
+    def checkout(self, branchname: str) -> None:
+        """Checkout a branch.
+
+        Parameters:
+            branchname: The name of the branch.
+        """
+        self.git("checkout", branchname)
+
+    def merge(self, branchname: str) -> str:
+        """Merge a branch into the current branch, creating a new merge commit.
+
+        Parameters:
+            branchname: The name of the branch to merge.
+
+        Returns:
+            The Git commit hash of the merge commit.
+        """
+        self.git("merge", "--no-ff", "--commit", "-m", f"merge: Merge branch '{branchname}'", branchname)
+        return self.git("rev-parse", "HEAD").rstrip()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -58,3 +58,11 @@ class GitRepo:
         self.git("add", "-A")
         self.git("commit", "-m", message)
         return self.git("rev-parse", "HEAD")
+
+    def tag(self, tagname: str) -> None:
+        """Create a new tag in the GIt repository.
+
+        Parameters:
+            tagname: The name of the new tag.
+        """
+        self.git("tag", tagname)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -22,8 +22,24 @@ def test_bump_with_semver_on_new_repo(repo: GitRepo, bump: str, expected: str) -
 
     Parameters:
         repo: GitRepo to a temporary repository.
+        bump: The bump parameter value.
         expected: Expected version for the new changelog entry.
     """
     changelog = Changelog(repo.path, convention=AngularConvention, bump=bump)
     assert len(changelog.versions_list) == 1
     assert changelog.versions_list[0].tag == expected
+
+
+@pytest.mark.parametrize("bump", ["auto", "major", "minor", "2.0.0"])
+def test_no_bump_on_first_tag(repo: GitRepo, bump: str) -> None:
+    """Ignore bump on new git repo without unreleased commits.
+
+    Parameters:
+        repo: GitRepo to a temporary repository.
+        bump: The bump parameter value.
+    """
+    repo.tag("1.1.1")
+
+    changelog = Changelog(repo.path, convention=AngularConvention, bump=bump)
+    assert len(changelog.versions_list) == 1
+    assert changelog.versions_list[0].tag == "1.1.1"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -43,3 +43,80 @@ def test_no_bump_on_first_tag(repo: GitRepo, bump: str) -> None:
     changelog = Changelog(repo.path, convention=AngularConvention, bump=bump)
     assert len(changelog.versions_list) == 1
     assert changelog.versions_list[0].tag == "1.1.1"
+
+
+def test_one_release_branch_with_feat_branch(repo: GitRepo) -> None:
+    r"""Test parsing and grouping commits to versions.
+
+    Commit graph:
+                   1.0.0
+                     |
+    main       A-B---D
+                \   /
+    feat         --C
+
+    Expected:
+    - 1.0.0: D B C A
+
+    Parameters:
+        repo: GitRepo to a temporary repository.
+    """
+    commit_a = repo.first_hash
+    repo.branch("develop")
+    commit_b = repo.commit("fix: B")
+    repo.checkout("develop")
+    commit_c = repo.commit("feat: C")
+    repo.checkout("main")
+    commit_d = repo.merge("develop")
+    repo.tag("1.0.0")
+
+    changelog = Changelog(repo.path, convention=AngularConvention)
+
+    assert len(changelog.versions_list) == 1
+    version = changelog.versions_list[0]
+    assert version.tag == "1.0.0"
+    assert len(version.commits) == 4
+    hashes = [commit.hash for commit in version.commits]
+    assert hashes == [commit_d, commit_b, commit_c, commit_a]
+
+
+def test_one_release_branch_with_two_versions(repo: GitRepo) -> None:
+    r"""Test parsing and grouping commits to versions.
+
+    Commit graph:
+                   1.1.0
+               1.0.0 |
+                 |   |
+    main       A-B---D
+                \   /
+    feat         --C
+
+    Expected:
+    - 1.1.0: D C
+    - 1.0.0: B A
+
+    Parameters:
+        repo: GitRepo to a temporary repository.
+    """
+    commit_a = repo.first_hash
+    repo.branch("develop")
+    commit_b = repo.commit("fix: B")
+    repo.tag("1.0.0")
+    repo.checkout("develop")
+    commit_c = repo.commit("feat: C")
+    repo.checkout("main")
+    commit_d = repo.merge("develop")
+    repo.tag("1.1.0")
+
+    changelog = Changelog(repo.path, convention=AngularConvention)
+
+    assert len(changelog.versions_list) == 2
+    version = changelog.versions_list[0]
+    assert version.tag == "1.1.0"
+    hashes = [commit.hash for commit in version.commits]
+    assert hashes == [commit_d, commit_c]
+
+    version = changelog.versions_list[1]
+    assert version.tag == "1.0.0"
+    hashes = [commit.hash for commit in version.commits]
+    assert hashes == [commit_b, commit_a]


### PR DESCRIPTION
This is my attempt at fixing #70.

The solution in this PR is different from #70, but in my opinion, it makes the code easier to read and understand.
The first solution had some issues with certain commit graphs (especially, when there are more than one previous version).

I made the following assumptions:

- A commit should only be listed in exactly one version. And this version is the oldest version.
- The previous version is the one that is found when following the left branch of the commit graph (ignoring merges).

I'll need to test this a bit more (especially if the last assumption is OK), but wanted to open this PR to get an early feedback.

I removed the `Version.next_version` field. If it is better to keep it, I can reintroduce it.

One of the tests has an ugly `sleep(1)` in it. Unfortunately Git only has second precision and without the sleep, the comit order of `git log` is undetermined for commits that happen in the same second (and are not related).  

And one final not, this PR is based on #71.