### PR TITLE
feat: Support for additional template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ Automatic Changelog generator using Jinja2 templates. From git logs to change lo
 - Parses [Git trailers][git-trailers], allowing to reference
   issues, PRs, etc., in your commit messages
   in a clean, provider-agnostic way.
+- Template context injection,
+  to furthermore customize how your changelog will be rendered.
 
 - Todo:
     - [Plugin architecture][issue-19],
       to support more commit conventions and git services.
-    - [Template context injection][issue-17],
-      to furthermore customize how your changelog will be rendered.
     - [Easy access to "Breaking Changes"][issue-14] in the templates.
-    - [Commits/dates/versions range limitation ability][issue-16].
 
 [jinja2]:                 http://jinja.pocoo.org/
 [keep-a-changelog]:       http://keepachangelog.com/en/1.0.0/
@@ -47,9 +46,6 @@ Automatic Changelog generator using Jinja2 templates. From git logs to change lo
 [git-trailers]:           https://git-scm.com/docs/git-interpret-trailers
 
 [issue-14]: https://github.com/pawamoy/git-changelog/issues/14
-[issue-15]: https://github.com/pawamoy/git-changelog/issues/15
-[issue-16]: https://github.com/pawamoy/git-changelog/issues/16
-[issue-17]: https://github.com/pawamoy/git-changelog/issues/17
 [issue-19]: https://github.com/pawamoy/git-changelog/issues/19
 
 ## Installation
@@ -68,16 +64,6 @@ pipx install git-changelog
 ```
 
 ## Usage
-
-```
-git-changelog [--config-file [PATH ...]] [-b] [-B VERSION] [-h] [-i]
-              [-g VERSION_REGEX] [-m MARKER_LINE] [-o OUTPUT]
-              [-p {github,gitlab,bitbucket}] [-r] [-R] [-I INPUT]
-              [-c {angular,conventional,basic}] [-s SECTIONS]
-              [-t {angular,keepachangelog}] [-T] [-E] [-Z] [-F FILTER_COMMITS]
-              [-V] [--debug-info]
-              [REPOSITORY]
-```
 
 Simply run `git-changelog` in your repository to output a changelog on standard output.
 To show the different options and their descriptions, use `git-changelog -h`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -384,8 +384,9 @@ git-changelog -t path:changelog.md -j footer="Copyright 2024 My Company"
 ...or with the configuration option:
 
 ```toml
-[jinja_context]
 template = "path:changelog.md"
+
+[jinja_context]
 footer = "Copyright 2024 My Company"
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -287,12 +287,106 @@ git-changelog --template keepachangelog
 You can also write and use your own changelog templates.
 Templates are single files written using the [Jinja][jinja] templating engine.
 You can get inspiration from
-[the source of our built-in templates](https://github.com/pawamoy/git-changelog/tree/master/src/git_changelog/templates).
+[the source of our built-in templates][builtin-templates].
 
-Prefix value passed to the `--template` option with `path:` to use a custom template:
+Prefix the value passed to the `--template` option with `path:` to use a custom template:
 
 ```bash
 git-changelog --template path:mytemplate.md
+```
+
+### Writing a changelog template
+
+To write your own changelog template,
+we recommend using our [keepachangelog built-in template][keepachangelog-template]
+as a starting point.
+
+From there, simply modify the different Jinja macros:
+
+- `render_commit()`, which accepts a [Commit][git_changelog.build.Commit] object
+- `render_section()`, which accepts a [Section][git_changelog.build.Section] object
+- `render_version()`, which accepts a [Version][git_changelog.build.Version] object
+
+Then, also update the template at the end, to change the changelog's header
+or add a changelog footer for example.
+
+The variables available in the template are `changelog`,
+which is a [Changelog][git_changelog.build.Changelog] instance,
+and `in_place`, which is a boolean, and tells whether the changelog
+is being updated in-place.
+
+> QUESTION: **How to get spacing right?**
+> Although spacing (line jumps) is not super important in Markdown contents
+> (it won't change HTML output), it is best if you get spacing right,
+> as it makes prettier changelog files, and will reduce the noise
+> in diffs when you commit an update to your changelog.
+>
+> To manage spacing (in Jinja terms, [control whitespace][control-whitespace])
+> Jinja allows to "eat" spaces on the left or right of an expression,
+> by adding a dash after/before the percent sign: `{%-` and `-%}`.
+> However, spacing is not always easy to get right with Jinja,
+> so here are two tips that we find helpful:
+>
+> - **To collapse content up**, eat spaces on the **left**, and add new lines
+>     at the **top** of the Jinja block:
+>
+>     ```django
+>     Some text.
+>     {%- if some_condition %}
+>
+>     Some content.
+>     {%- endif %}
+>     ```
+>
+>     If the condition is true, there will be exactly one blank line
+>     between "Some text" and "Some content". If not, there won't be
+>     extreanous trailing blank lines :+1:
+>
+> - **To collapse content down**, eat spaces on the **right**, and add new lines
+>     at the **bottom** of the Jinja block:
+>
+>     ```django
+>     {% if some_condition -%}
+>     Some content.
+>
+>     {% endif -%}
+>     Some text.
+>     ```
+>
+>     If the condition is true, there will be exactly one blank line
+>     between "Some content" and "Some text". If not, there won't be
+>     extreanous leading blank lines :+1:
+
+### Extra Jinja context
+
+[(--jinja-context)](cli.md#jinja_context)
+
+Your custom changelog templates can support user-provided extra Jinja context.
+This extra context is available in the `jinja_context` variable, which is a dictionary,
+and is passed by users with the `-j`, `--jinja-context` CLI option
+or with the `jinja_context` configuration option.
+
+For example, you could let users specify their own changelog footer
+by adding this at the end of your template:
+
+```django
+{% if jinja_context.footer %}
+{{ jinja_context.footer }}
+{% endif %}
+```
+
+Then users would be able to provide their own footer with the CLI option:
+
+```bash
+git-changelog -t path:changelog.md -j footer="Copyright 2024 My Company"
+```
+
+...or with the configuration option:
+
+```toml
+[jinja_context]
+template = "path:changelog.md"
+footer = "Copyright 2024 My Company"
 ```
 
 ## Filter commits
@@ -589,3 +683,6 @@ and `--marker-line`.
 [semver]: https://semver.org/
 [git-trailers]: https://git-scm.com/docs/git-interpret-trailers
 [softprops/action-gh-release]: https://github.com/softprops/action-gh-release
+[keepachangelog-template]: https://github.com/pawamoy/git-changelog/tree/main/src/git_changelog/templates/keepachangelog.md
+[builtin-templates]: https://github.com/pawamoy/git-changelog/tree/main/src/git_changelog/templates
+[control-whitespace]: https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -112,8 +112,9 @@ class _ParseDictAction(argparse.Action):
         attribute = getattr(namespace, self.dest)
         if not isinstance(attribute, dict):
             setattr(namespace, self.dest, {})
-        if isinstance(values, list) and len(values) == 2:  # noqa: PLR2004
-            getattr(namespace, self.dest)[values[0]] = values[1]
+        if isinstance(values, str):
+            key, value = values.split("=", 1)
+            getattr(namespace, self.dest)[key] = value
 
 
 providers: dict[str, type[ProviderRefParser]] = {
@@ -353,8 +354,7 @@ def get_parser() -> argparse.ArgumentParser:
         "-j",
         "--jinja-context",
         action=_ParseDictAction,
-        metavar=("KEY", "VALUE"),
-        nargs=2,
+        metavar="KEY=VALUE",
         dest="jinja_context",
         help="Pass additional key/value pairs to the template. Option can be used multiple times. "
         "The key/value pairs are accessible as 'jinja_context' in the template.",

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -492,10 +492,7 @@ def parse_settings(args: list[str] | None = None) -> dict:
     settings.update(explicit_opts_dict)
 
     # Merge jinja context, CLI values override config file values.
-    if jinja_context and settings.get("jinja_context"):
-        settings["jinja_context"].update(jinja_context)
-    elif jinja_context:
-        settings["jinja_context"] = jinja_context
+    settings["jinja_context"].update(jinja_context)
 
     # TODO: remove at some point
     if "bump_latest" in explicit_opts_dict:

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -521,7 +521,7 @@ def build_and_render(
     bump: str | None = None,
     zerover: bool = True,  # noqa: FBT001,FBT002
     filter_commits: str | None = None,
-    jinja_context: dict[str, str] | None = None,
+    jinja_context: dict[str, Any] | None = None,
 ) -> tuple[Changelog, str]:
     """Build a changelog and render it.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,5 +256,3 @@ def test_jinja_context(repo: GitRepo) -> None:
 
     contents = repo.path.joinpath("CHANGELOG.md").read_text()
     assert contents == "k1 = v1\nk2 = v2\nk3 = v3\n"
-
-    assert contents == "k1 = v1\nk2 = v2\nk3 = v3\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Iterator
 
 import pytest
@@ -224,11 +225,13 @@ def test_jinja_context(repo: GitRepo) -> None:
         repo: Temporary Git repository (fixture).
     """
     repo.path.joinpath("conf.toml").write_text(
-        """[jinja_context]
-        k1 = "ignored"
-        k2 = "v2"
-        k3 = "v3"
-        """.lstrip(),
+        dedent(
+            """[jinja_context]
+            k1 = "ignored"
+            k2 = "v2"
+            k3 = "v3"
+            """,
+        ),
     )
 
     template = repo.path.joinpath(".custom_template.md.jinja")
@@ -243,11 +246,9 @@ def test_jinja_context(repo: GitRepo) -> None:
             "-t",
             f"path:{template}",
             "--jinja-context",
-            "k1",
-            "v1",
+            "k1=v1",
             "-j",
-            "k3",
-            "v3",
+            "k3=v3",
             str(repo.path),
         ],
     )


### PR DESCRIPTION
When using a custom Jinja template to render the changelog, it would be great, if additional context information could be accessed in that template. This feature request should be related to #17.

With the changes in this PR, additional context can be passed as key/value pairs either via CLI or via the toml config file.

To pass variables via CLI, the option `--template-var KEY VALUE` can be given multiple times.

To define variables in a configuration file, the variables can be defined in a "[template_vars]"  table.

``` toml
[template_vars]
KEY = "VALUE"
```

When template vars are given via CLI and via config file, they are merged with the CLI vars taking precedence.

All values are accessible in the template through the "template_vars" (dict) variable.

The parsing of the CLI option into a dict is based on this gist: https://gist.github.com/vadimkantorov/37518ff88808af840884355c845049ea

(Unfortunately argparse does not support it out of the box, or at least I could not find a better way to achieve this)