### PR TITLE
fix: Ignore tags that are not a valid semver

### DIFF
--- a/src/git_changelog/commit.py
+++ b/src/git_changelog/commit.py
@@ -88,11 +88,11 @@ class Commit:
 
         tag = ""
         for ref in refs.split(","):
-            tag_ref = ref.strip()
-            if tag_ref.startswith("tag: "):
-                tag_ref = tag_ref.replace("tag: ", "")
-                if _is_semver(tag_ref):
-                    tag = tag_ref
+            ref = ref.strip()  # noqa: PLW2901
+            if ref.startswith("tag: "):
+                ref = ref.replace("tag: ", "")  # noqa: PLW2901
+                if _is_semver(ref):
+                    tag = ref
                     break
         self.tag: str = tag
         self.version: str = tag


### PR DESCRIPTION
When git-changelog finds a tag, that is not a semver, it fails with a ValueError (parsing the tag into a semver).

In my opinion, git-changelog should simply ignore tags that cannot be parsed into a semantic version.
This PR only keeps the tag information from git-log if it is a valid semantic version.