### PR TITLE
fix: Handle no remote gracefully

### DIFF
--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -309,7 +309,7 @@ class Changelog:
             The origin remote URL.
         """
         remote = "remote." + os.environ.get("GIT_CHANGELOG_REMOTE", "origin") + ".url"
-        git_url = self.run_git("config", "--get", remote).rstrip("\n")
+        git_url = self.run_git("config", "--default", "", "--get", remote).rstrip("\n")
         if git_url.startswith("git@"):
             git_url = git_url.replace(":", "/", 1).replace("git@", "https://", 1)
         if git_url.endswith(".git"):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -197,3 +197,24 @@ def _assert_version(
         assert version.previous_version is None
     hashes = [commit.hash for commit in version.commits]
     assert hashes == expected_commits
+
+
+def test_no_remote_url(repo: GitRepo) -> None:
+    r"""Test parsing and grouping commits to versions without a git remote.
+
+    Parameters:
+        repo: GitRepo to a temporary repository.
+    """
+    repo.git("remote", "remove", "origin")
+    commit_a = repo.first_hash
+    repo.tag("1.0.0")
+
+    changelog = Changelog(repo.path, convention=AngularConvention)
+
+    assert len(changelog.versions_list) == 1
+    _assert_version(
+        changelog.versions_list[0],
+        expected_tag="1.0.0",
+        expected_prev_tag=None,
+        expected_commits=[commit_a],
+    )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -200,7 +200,7 @@ def _assert_version(
 
 
 def test_no_remote_url(repo: GitRepo) -> None:
-    r"""Test parsing and grouping commits to versions without a git remote.
+    """Test parsing and grouping commits to versions without a git remote.
 
     Parameters:
         repo: GitRepo to a temporary repository.


### PR DESCRIPTION
Fix for #24 

With this change, git-changelog does not fail any more, if it cannot find a remote.
The generated changelog is not perfect. All the links have no target url.
Given that this is an edge case, maybe this is good enough? 

Example output without remote:

``` markdown
## [1.0.0]() - 2024-03-02

<small>[Compare with 0.1.0]()</small>

### Features

- New feature for planned v1.0.0 ([3dba998]() by Christian Meffert).

## [0.1.0]() - 2024-03-02

<small>[Compare with first commit]()</small>
```