### PR TITLE
fix: Duplicate commits for unreleased version with merged brances

### DIFF
--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -157,7 +157,7 @@ class Version:
             commit: The git commit.
         """
         self.commits.append(commit)
-        commit.version = self.tag
+        commit.version = self.tag or "HEAD"
         if commit_type := commit.convention.get("type"):
             if commit_type not in self.sections_dict:
                 section = Section(section_type=commit_type)


### PR DESCRIPTION
Unfortunately the new logic to follow the commit graph to assign commits to versions has one bug.

If there are merge commits into the unreleased version, all following commits will be counted twice. And this applies for each merge commit (and with lots of merges, this results also in quite a performance issue - I first thought it is an endless loop ...).

The problematic part is "marking" a commit to be already assigned to a version, to not assign it again (and stop following the commit graph), only works if the version string is not empty. This is not the case for the unreleased version.

For example, given the following commit graph:

``` mermaid
gitGraph
   commit id: "A"
   branch feat/1
   checkout feat/1
   commit id: "B"
   checkout main
   merge feat/1 id: "C"
   branch feat/2
   checkout feat/2
   commit id: "D"
   checkout main
   merge feat/2 id: "E"
```

This results in an unreleased version with:

- E
- C
- A
- B
- A
- D
- C
- A
- B
- A

This solution implemented in this PR is to assign the commits a "HEAD" version if they belong to the unreleased version.
This avoids that the commits are added more than once. 