### PR TITLE
fix: restore commits for untyped section

### DIFF
--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -159,12 +159,12 @@ class Version:
         """
         self.commits.append(commit)
         commit.version = self.tag or "HEAD"
-        if commit_type := commit.convention.get("type"):
-            if commit_type not in self.sections_dict:
-                section = Section(section_type=commit_type)
-                self.sections_list.append(section)
-                self.sections_dict[commit_type] = section
-            self.sections_dict[commit_type].commits.append(commit)
+        commit_type = commit.convention.get("type")
+        if commit_type not in self.sections_dict:
+            section = Section(section_type=commit_type)
+            self.sections_list.append(section)
+            self.sections_dict[commit_type] = section
+        self.sections_dict[commit_type].commits.append(commit)
 
 
 class Changelog:


### PR DESCRIPTION
Issue: #88 
Resolves: #88

In versions prior to 2.4.1, Jinja templates could optionally generate change lines by accessing the `""` section (e.g. `untyped_section`). This allowed for capturing of commit messages that would otherwise be lost.

Upon version 2.4.1, that was broken and `untyped_section` became always empty.

This PR restores the functionality.