### PR TITLE
feat: Add JIRA issues parsing

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,12 @@ Generate a changelog using a specific provider (GitHub/GitLab/BitBucket):
 git-changelog --provider github
 ```
 
+Generate a changelog with a list of JIRA issues addressed per version:
+
+```bash
+git-changelog --jira-url https://<subdomain>.atlassian.net/browse/<project>-%
+```
+
 Author's favorite, from Python:
 
 ```python

--- a/src/git_changelog/build.py
+++ b/src/git_changelog/build.py
@@ -151,6 +151,19 @@ class Version:
         """
         return bool(self.tag.split(".", 2)[2])
 
+    @property
+    def jira_issues(self) -> dict[str, str]:
+        """List the JIRA issues associated to this version.
+
+        Returns:
+           A dictionnary of all the JIRA issues referenced in this version's commits and their URLs.
+        """
+        return {
+            key: url
+            for commit in self.commits
+            for key, url in commit.convention.get("jira_issues", {}).items()
+        }
+
     def add_commit(self, commit: Commit) -> None:
         """Register the given commit and add it to the relevant section based on its message convention.
 
@@ -204,6 +217,7 @@ class Changelog:
         zerover: bool = True,
         filter_commits: str | None = None,
         versioning: Literal["semver", "pep440"] = "semver",
+        jira_info: dict[str, str] | None = None,
     ):
         """Initialization method.
 
@@ -224,6 +238,7 @@ class Changelog:
         self.parse_trailers: bool = parse_trailers
         self.zerover: bool = zerover
         self.filter_commits: str | None = filter_commits
+        self.jira_info: dict[str, str] | None = jira_info
 
         # set provider
         if not isinstance(provider, ProviderRefParser):
@@ -384,6 +399,7 @@ class Changelog:
                 body=body,
                 parse_trailers=self.parse_trailers,
                 version_parser=self.version_parser,
+                jira_info=self.jira_info,
             )
 
             pos += nbl_index + 1

--- a/src/git_changelog/templates/angular.md.jinja
+++ b/src/git_changelog/templates/angular.md.jinja
@@ -34,6 +34,12 @@
 {%- endwith %}
 {%- endif %}
 {%- endfor %}
+{%- if version.jira_issues|length > 0 %}
+### JIRA issues
+{% for issue_key, issue_url in version.jira_issues.items() %}
+- [{{ issue_key }}]({{ issue_url }})
+{%- endfor %}
+{% endif %}
 {%- if not (version.tag or version.planned_tag) %}
 <!-- insertion marker -->{% endif %}
 {% endmacro -%}

--- a/src/git_changelog/templates/keepachangelog.md.jinja
+++ b/src/git_changelog/templates/keepachangelog.md.jinja
@@ -38,6 +38,12 @@
 {%- endwith %}
 {%- endif %}
 {%- endfor %}
+{%- if version.jira_issues|length > 0 %}
+### JIRA issues
+{% for issue_key, issue_url in version.jira_issues.items() %}
+- [{{ issue_key }}]({{ issue_url }})
+{%- endfor %}
+{% endif %}
 {%- if not (version.tag or version.planned_tag) %}
 <!-- insertion marker -->{% endif %}
 {% endmacro -%}


### PR DESCRIPTION
When a JIRA issue is referenced in a commit, it is now possible to parse it. The JIRA issues will then be added to a dedicated section for each version.