### PR TITLE
Fix/quality checks

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,7 +88,7 @@ The following sections explain in more details all the features of *git-changelo
 
 Project-wise, permanent configuration of *git-changelog* is possible.
 By default, *git-changelog* will search for the existence a suitable configuration
-in the `pyproject.toml` file or otherwise, the following configuration files 
+in the `pyproject.toml` file or otherwise, the following configuration files
 in this particular order:
 
 - `.git-changelog.toml`
@@ -309,7 +309,7 @@ as a starting point.
 
 From there, simply modify the different Jinja macros:
 
-- `render_commit()`, which accepts a [Commit][git_changelog.build.Commit] object
+- `render_commit()`, which accepts a [Commit][git_changelog.commit.Commit] object
 - `render_section()`, which accepts a [Section][git_changelog.build.Section] object
 - `render_version()`, which accepts a [Version][git_changelog.build.Version] object
 
@@ -406,7 +406,7 @@ project has migrated to SemVer recently and you want to ignore old non-conventio
 This is possible through the option `-F`, `--filter-commits`, which takes a
 *revision-range* to select the commits that will be used in the changelog.
 This option will pass the [revision-range](https://git-scm.com/docs/git-log#
-Documentation/git-log.txt-ltrevision-rangegt) to `git log`, so it will follow 
+Documentation/git-log.txt-ltrevision-rangegt) to `git log`, so it will follow
 the rules defined by Git.
 
 For example, to use commits from tag `0.5.0` up to latest:

--- a/duties.py
+++ b/duties.py
@@ -188,7 +188,7 @@ def coverage(ctx: Context) -> None:
 
 
 @duty
-def test(ctx: Context, *cli_args: str, match: str = "") -> None:
+def test(ctx: Context, *cli_args: str, match: str = "") -> None:  # noqa: PT028
     """Run the test suite.
 
     Parameters:
@@ -217,16 +217,16 @@ def profile(ctx: Context, merge: int = 15) -> None:
     # Do not import those from the top level,
     # as it prevents the pytest-cov plugin for marking
     # lines executed at import time as covered.
-    from git_changelog import Changelog
-    from git_changelog.commit import AngularConvention
+    from git_changelog import Changelog  # noqa: PLC0415
+    from git_changelog.commit import AngularConvention  # noqa: PLC0415
 
     try:
-        from tests.helpers import GitRepo
+        from tests.helpers import GitRepo  # noqa: PLC0415
     except ModuleNotFoundError:
-        import sys
+        import sys  # noqa: PLC0415
 
         sys.path.insert(0, str(Path(__file__).parent))
-        from tests.helpers import GitRepo
+        from tests.helpers import GitRepo  # noqa: PLC0415
 
     def merge_branches(repo: GitRepo, branch: str = "feat", times: int = 15) -> None:
         for _ in range(times):

--- a/src/git_changelog/cli.py
+++ b/src/git_changelog/cli.py
@@ -497,7 +497,7 @@ def parse_settings(args: list[str] | None = None) -> dict:
 
     # Determine which arguments were explicitly set with the CLI
     sentinel = object()
-    sentinel_ns = argparse.Namespace(**{key: sentinel for key in opts})
+    sentinel_ns = argparse.Namespace(**dict.fromkeys(opts, sentinel))
     explicit_opts_dict = {
         key: opts.get(key, None)
         for key, value in vars(parser.parse_args(namespace=sentinel_ns, args=args)).items()

--- a/src/git_changelog/commit.py
+++ b/src/git_changelog/commit.py
@@ -306,7 +306,7 @@ class CommitConvention(ABC):
             r"\n *",
             "\n",
             f"""
-            #### {cls.__name__[:-(len('Convention'))].strip()}
+            #### {cls.__name__[: -(len("Convention"))].strip()}
 
             *Default sections:*
 

--- a/src/git_changelog/versioning.py
+++ b/src/git_changelog/versioning.py
@@ -56,8 +56,12 @@ PEP440Strategy = Literal[
 _release_kind = {"a": "alpha", "b": "beta", "c": "candidate", "rc": "candidate", "p": "post"}
 
 
-class ParsedVersion(Protocol):
-    """Base class for versioning schemes."""
+class ParsedVersion(Protocol):  # noqa: PLW1641
+    """Base class for versioning schemes.
+
+    IMPORTANT: For backward compatabillity it's not necesary to implement __hash__ method
+    but it's recommended to do so (see PLW1641: https://docs.astral.sh/ruff/rules/eq-without-hash/).
+    """
 
     def __lt__(self, other: object) -> bool: ...
     def __le__(self, other: object) -> bool: ...
@@ -65,6 +69,8 @@ class ParsedVersion(Protocol):
     def __ge__(self, other: object) -> bool: ...
     def __gt__(self, other: object) -> bool: ...
     def __ne__(self, other: object) -> bool: ...
+
+    # TODO: in next major version it's better to add `def __hash__(self) -> int: ...`
 
 
 class SemVerVersion(semver.Version, ParsedVersion):  # type: ignore[misc]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,19 +174,19 @@ def test_settings_warning(
         with pytest.warns(FutureWarning) as record:
             cli.parse_settings(args)
 
-            solution = "is deprecated in favor of"  # Warning comes from CLI parsing.
-            if value is not None:  # Warning is issued when parsing the config file.
-                solution = "remove" if not value else "auto"
+        solution = "is deprecated in favor of"  # Warning comes from CLI parsing.
+        if value is not None:  # Warning is issued when parsing the config file.
+            solution = "remove" if not value else "auto"
 
-            assert len(record) == 1
-            assert solution in str(record[0].message)
+        assert len(record) == 1
+        assert solution in str(record[0].message)
 
         # If setting is in config file AND passed by CLI, two FutureWarnings are issued.
         if (tmp_path / ".git-changelog.toml").exists():
             with pytest.warns(FutureWarning) as record:
                 cli.parse_settings(["--bump-latest"])
 
-                assert len(record) == 2
+            assert len(record) == 2
 
 
 # IMPORTANT: See top module comment.

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -46,13 +46,19 @@ def test_trailers_emit_deprecation_warnings() -> None:
         subject="Summary",
         parse_trailers=True,
     )
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Trailers are now a list of 2-tuples."):
         assert not commit.trailers.keys()  # type: ignore[attr-defined]
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Trailers are now a list of 2-tuples."):
         assert not commit.trailers.values()  # type: ignore[attr-defined]
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Trailers are now a list of 2-tuples."):
         assert not commit.trailers.items()  # type: ignore[attr-defined]
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Trailers are now a list of 2-tuples."):
         assert not commit.trailers.get("key")  # type: ignore[attr-defined]
-    with pytest.warns(DeprecationWarning), pytest.raises(KeyError):
+    with (
+        pytest.warns(
+            DeprecationWarning,
+            match="Getting a trailer with a string key will stop being supported in version 3. Instead, use an integer index, or iterate.",
+        ),
+        pytest.raises(KeyError),
+    ):
         assert not commit.trailers["key"]  # type: ignore[call-overload]

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from git_changelog.versioning import (
+    ParsedVersion,
     PEP440Strategy,
     PEP440Version,
     SemVerStrategy,
@@ -366,3 +367,40 @@ def test_pep440_dent_error(part: PEP440Strategy, version: str) -> None:
     """
     with pytest.raises(ValueError, match="Cannot dent"):
         getattr(PEP440Version(version), f"dent_{part}")()
+
+
+def test_parsed_version_protocol_allow_unhashable() -> None:
+    """Test that unhashable versions are allowed."""
+
+    class NonHashableVersion(ParsedVersion):  # noqa: PLW1641
+        def __lt__(self, other: object) -> bool:
+            return False
+
+        def __le__(self, other: object) -> bool:
+            return False
+
+        def __eq__(self, other: object) -> bool:
+            return False
+
+        def __ge__(self, other: object) -> bool:
+            return False
+
+        def __gt__(self, other: object) -> bool:
+            return False
+
+        def __ne__(self, other: object) -> bool:
+            return False
+
+    version_a = NonHashableVersion()
+    version_b = NonHashableVersion()
+
+    with pytest.raises(TypeError, match="unhashable"):
+        _ = {version_a, version_b}
+
+    class VersionWithoutParsedProtocol:
+        pass
+
+    version_c = VersionWithoutParsedProtocol()
+    version_d = VersionWithoutParsedProtocol()
+
+    assert len({version_c, version_d}) == 2


### PR DESCRIPTION
I left __hash__ out of the ParsedVersion protocol to preserve backward compatibility. To guide implementers, I added a docstring note recommending they define __hash__ when their ParsedVersion needs to be hashable (e.g., used as dict/set keys). I also added a test that makes the difference explicit by exercising behavior with and without a __hash__ implementation on a ParsedVersion type.