### PR TITLE
feat: Add CLI option --bumped-version to retrieve the bumped version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Gitter = "https://gitter.im/git-changelog/community"
 Funding = "https://github.com/sponsors/pawamoy"
 
 [project.scripts]
-git-changelog = "git_changelog.cli:main"
+git-changelog = "git_changelog:main"
 
 [tool.pdm.version]
 source = "call"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,7 +161,7 @@ def test_inventory_matches_api(
             and (item.name == "git_changelog" or item.name.startswith("git_changelog."))
         ):
             obj = loader.modules_collection[item.name]
-            if obj.path not in public_api_paths and not any(path in public_api_paths for path in obj.aliases):
+            if obj.path not in public_api_paths and not any(path in public_api_paths for path in obj.aliases):  # noqa: SIM102
                 # YORE: Bump 3: Replace block with line 8.
                 if obj.path not in (
                     "git_changelog.build",


### PR DESCRIPTION
### For reviewers

- [x] I did not use AI
- [ ] I used AI and thorougly reviewed every code/docs change

### Description of the change
Entry point for git-changelog used to use deprecation import, as result Deprecation warning appears on every run.

Also fix small quality check warning.

