### PR TITLE
fix: Follow conventional commit convention more strictly

### DIFF
--- a/src/git_changelog/_internal/commit.py
+++ b/src/git_changelog/_internal/commit.py
@@ -554,7 +554,7 @@ class ConventionalCommitConvention(AngularConvention):
         message = "\n".join([commit.subject, *commit.body])
         is_major = self.is_major(message) or subject.get("breaking") == "!"
         is_minor = not is_major and self.is_minor(subject["type"])
-        is_patch = not any((is_major, is_minor))
+        is_patch = self.is_patch(subject["type"])
 
         return {
             "type": subject["type"],
@@ -564,3 +564,14 @@ class ConventionalCommitConvention(AngularConvention):
             "is_minor": is_minor,
             "is_patch": is_patch,
         }
+
+    def is_patch(self, commit_type: str) -> bool:
+        """Tell if this commit is worth a patch bump.
+
+        Parameters:
+            commit_type: The commit type.
+
+        Returns:
+            Whether it's a patch commit.
+        """
+        return commit_type == self.TYPES["fix"]

--- a/tests/test_conventional_commit_style.py
+++ b/tests/test_conventional_commit_style.py
@@ -155,3 +155,21 @@ def test_conventional_convention_fix_with_scope() -> None:
     assert not commit_dict["is_major"]
     assert not commit_dict["is_minor"]
     assert commit_dict["is_patch"]
+
+
+def test_conventional_convention_no_bump() -> None:
+    """Non bumping commit is correctly identified."""
+    subject = "ci: this is a CI commit"
+    commit = Commit(
+        commit_hash="aaaaaaa",
+        subject=subject,
+        author_date="1574340645",
+        committer_date="1574340645",
+    )
+    convention = ConventionalCommitConvention()
+    commit_dict = convention.parse_commit(commit)
+    assert commit_dict["type"] == "Continuous Integration"
+    assert commit_dict["scope"] is None
+    assert not commit_dict["is_major"]
+    assert not commit_dict["is_minor"]
+    assert not commit_dict["is_patch"]


### PR DESCRIPTION


### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thorougly reviewed every code/docs change

### Description of the change
According to [Conventional Commit Convention](https://www.conventionalcommits.org/en/v1.0.0/):

_Additional types [besides "feat" and "fix"] are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE)_

### Relevant resources
- [Conventional Commit Convention](https://www.conventionalcommits.org/en/v1.0.0/)

-
-
-
