### PR TITLE
fix: remove duplicate section keys

### DIFF
--- a/src/git_changelog/_internal/build.py
+++ b/src/git_changelog/_internal/build.py
@@ -301,7 +301,7 @@ class Changelog:
         # Set sections.
         if sections and ":all:" in sections:
             # Expand :all: to all available section types.
-            sections = list(self.convention.TYPES.values())
+            sections = list(dict.fromkeys(self.convention.TYPES.values()))
         elif sections:
             sections = [self.convention.TYPES[section] for section in sections]
         else:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -482,7 +482,7 @@ def test_sections_all_expands_to_all_types(repo: GitRepo) -> None:
     changelog = Changelog(repo.path, convention=AngularConvention, sections=[":all:"])
 
     # AngularConvention.TYPES contains all available section types.
-    expected_sections = list(AngularConvention.TYPES.values())
+    expected_sections = list(dict.fromkeys(AngularConvention.TYPES.values()))
     assert changelog.sections == expected_sections
 
 


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

When using `--sections :all:`, the code expanded to `list(TYPES.values())` which included duplicate section names because some type keys map to the same section:

- "doc" and "docs" → "Docs"
- "test" and "tests" → "Tests"
- "ref" and "refactor" → "Code Refactoring"

Changed to use use `dict.fromkeys()` to deduplicate while preserving order:

```python
sections = list(dict.fromkeys(self.convention.TYPES.values()))
```

