### PR TITLE
fix: Change Debian template to wrap long commit message

### DIFF
--- a/src/git_changelog/_internal/templates/debian.md.jinja
+++ b/src/git_changelog/_internal/templates/debian.md.jinja
@@ -13,7 +13,7 @@
 {%- for version in changelog.versions_list -%}
 {{ jinja_context.debian_package_name or "debian-package-name" }} ({{ deb_version(version)}}) {{ deb_distribution(version) }}; urgency=medium
 {% for commit in version.commits | sort(attribute="author_date") | unique(attribute="subject") %}
-  * {{ commit.subject }}
+{{ ('  * ' + commit.subject) | wordwrap(80, break_long_words=False, wrapstring="\n    ") }}
 {%- endfor %}
 
 {% set last_commit = version.commits | sort(attribute="author_date", reverse=True) | first -%}


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
To avoid raising warnings in lintian, let wrap long commit message on multiple lines.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->
Specific lintian warning:
```
W: sd-linux: debian-changelog-line-too-long [usr/share/doc/sd-linux/changelog.Debian.gz:11]
N: 
N:   The given line of the latest changelog entry is over 80 columns. Such
N:   changelog entries may look poor in terminal windows and mail messages and
N:   be annoying to read. Please wrap changelog entries at 80 columns or less
N:   where possible.
N: 
N:   Visibility: warning
N:   Show-Always: no
N:   Check: debian/changelog
```

