### PR TITLE
fix: debian version fallback when no previous tag exists

### DIFF
--- a/src/git_changelog/_internal/templates/debian.md.jinja
+++ b/src/git_changelog/_internal/templates/debian.md.jinja
@@ -1,8 +1,10 @@
 {%- macro deb_version(version) -%}
 {% if version.tag or version.planned_tag %}
 {{- (version.tag or version.planned_tag).lstrip("v") }}{{ jinja_context.debian_version_suffix -}}
-{% else %}
+{% elif version.previous_version %}
 {{- version.previous_version.tag.lstrip("v") }}+{{ version.date.strftime("%Y%m%d") -}}{{ jinja_context.debian_version_suffix -}}
+{%- else -%}
+0.0.0+{{ version.date.strftime("%Y%m%d") -}}{{ jinja_context.debian_version_suffix -}}
 {% endif %}
 {%- endmacro -%}
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -143,6 +143,27 @@ def test_rendering_debian_prepend(repo: GitRepo, tmp_path: Path) -> None:
     assert latest_tag in rendered
     repo.git("tag", "-d", latest_tag)
 
+@pytest.mark.parametrize("repo", [("",)], indirect=True)
+def test_rendering_debian_no_previous_version(repo: GitRepo, tmp_path: Path) -> None:
+    """Render changelog in-place.
+
+    Parameters:
+        repo: Temporary Git repository (fixture).
+        tmp_path: A temporary path to write the changelog into.
+    """
+    output = tmp_path.joinpath("changelog")
+    _, rendered = build_and_render(
+        str(repo.path),
+        convention="angular",
+        bump=None,
+        output=output.as_posix(),
+        template="debian",
+        jinja_context={
+            "debian_package_name": "my-pkg-name",
+            "debian_version_suffix": "+dfsg-1",
+        },
+    )
+    assert re.match(r"my-pkg-name \(0.0.0\+\d+\+dfsg-1\) UNRELEASED;", rendered)
 
 @pytest.mark.parametrize("repo", [VERSIONS, VERSIONS_V], indirect=True)
 def test_no_duplicate_rendering(repo: GitRepo, tmp_path: Path) -> None:


### PR DESCRIPTION
### For reviewers
- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
When starting from scratch with a new git repo without any tags, the current template for Debian is failing because there's no fallback to provide an initial version. This PR resolved this issue by providing, the safest version possible, which is 0.0.0+date

### Relevant resources
N/A
